### PR TITLE
support node 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ env:
   global:
     - SKIP_SASS_BINARY_DOWNLOAD_FOR_CI=true
   matrix:
+    - export NODE_VERSION="10"
     - export NODE_VERSION="8"
     - export NODE_VERSION="7"
     - export NODE_VERSION="6"
     - export NODE_VERSION="5"
-    - export NODE_VERSION="4"
 
 matrix:
   fast_finish: true
@@ -24,8 +24,8 @@ addons:
     sources:
       - ubuntu-toolchain-r-test
     packages:
-      - gcc-4.7
-      - g++-4.7
+      - gcc-4.9
+      - g++-4.9
 
 before_install:
   - git submodule update --init --recursive
@@ -36,10 +36,10 @@ before_install:
   - nvm use $NODE_VERSION
   - npm config set python `which python`
   - if [ $TRAVIS_OS_NAME == "linux" ]; then
-      export CC="gcc-4.7";
-      export CXX="g++-4.7";
-      export LINK="gcc-4.7";
-      export LINKXX="g++-4.7";
+      export CC="gcc-4.9";
+      export CXX="g++-4.9";
+      export LINK="gcc-4.9";
+      export LINKXX="g++-4.9";
     fi
   - nvm --version
   - node --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,11 +22,11 @@
   environment:
     SKIP_SASS_BINARY_DOWNLOAD_FOR_CI: true
     matrix:
+      - nodejs_version: 10
       - nodejs_version: 8
       - nodejs_version: 7
       - nodejs_version: 6
       - nodejs_version: 5
-      - nodejs_version: 4
 
   install:
     - ps: Install-Product node $env:nodejs_version $env:platform

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/node-sass",
-  "version": "3.4.4",
+  "version": "3.4.5",
   "libsass": "3.3.2",
   "description": "Wrapper around libsass",
   "license": "MIT",

--- a/src/callback_bridge.h
+++ b/src/callback_bridge.h
@@ -107,7 +107,7 @@ T CallbackBridge<T, L>::operator()(std::vector<void*> argv) {
     argv_v8.push_back(Nan::New(wrapper));
 
     return this->post_process_return_value(
-      this->callback->Call(argv_v8.size(), &argv_v8[0])
+      Nan::Call(*this->callback, argv_v8.size(), &argv_v8[0]).ToLocalChecked()
     );
   } else {
     /* 


### PR DESCRIPTION
Support for node 10 involve a change for callback_bridge.h. 
Adding node 10 caused the tests to fail. We debugged the code to find where the test fails exactly and followed changes that was made in node-saas. We haven't updated NaN package.

[node-sass PR](https://github.com/sass/node-sass/pull/2295) and the [commit](https://github.com/sass/node-sass/commit/1676810cdc26777aa7c186cf440d414fb2fb3dca#diff-953483bd71622742606ddb26e23f1e62R113) related to the change explanation:
Starting with Nan 2.9.0, we have the ability to propagate async context
across async hops. Certain variants of Nan::Callback::Call are now
deprecated to encourage use of the context presevering alternatives.
Certain variants of Node's MakeCallback that were used internally are
going to be deprecated in Node 10. 

Summary is that one should use Nan::Call for sync calls, and
Nan::Callback::Call for async. The latter expects an async resource
corresponding to the async operation to be provided at the call time.

This patch fixes things up so that 1) node-sass isn't using any
deprecated APIs, and 2) properly propagates async context for async
callbacks by creating async resources in the appropriate places.