### PR TITLE
Migrating to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
 
   build-darwin-node-7:
     macos:
-      xcode: "10.0.0"
+      xcode: "9.0.1"
     steps: 
       - install-node:
           version: 7

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,13 +56,6 @@ jobs:
       - build
       - release
 
-  build-linux-node-7:
-    docker: 
-      - image: circleci/node:7 
-    steps: 
-      - build
-      - release
-     
   build-linux-node-8:
     docker: 
       - image: circleci/node:8 
@@ -97,15 +90,6 @@ jobs:
     steps: 
       - install-node:
           version: 6
-      - build
-      - release
-
-  build-darwin-node-7:
-    macos:
-      xcode: "9.0.1"
-    steps: 
-      - install-node:
-          version: 7
       - build
       - release
 
@@ -215,13 +199,11 @@ workflows:
       - publish-github-release:
           requires:
             - build-linux-node-6
-            - build-linux-node-7
             - build-linux-node-8
             - build-linux-node-9
             - build-linux-node-10
             - build-linux-node-11
             - build-darwin-node-6
-            - build-darwin-node-7
             - build-darwin-node-8
             - build-darwin-node-9
             - build-darwin-node-10

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
 
   build-darwin-node-6:
     macos:
-      xcode: "10.0.0"
+      xcode: "9.0.1"
     steps: 
       - install-node:
           version: 6

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ commands:
           command: npm test
 
   release:
-    description: "Checkout, build, and test the package"
+    description: "Generate release artifact"
     steps:
       - run:
           name: release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,10 +151,6 @@ workflows:
           filters:
             tags:
               only: /v\d+\.\d+\.\d+$/
-      - build-linux-node-7:
-          filters:
-            tags:
-              only: /v\d+\.\d+\.\d+$/
       - build-linux-node-8:
           filters:
             tags:
@@ -172,10 +168,6 @@ workflows:
             tags:
               only: /v\d+\.\d+\.\d+$/
       - build-darwin-node-6:
-          filters:
-            tags:
-              only: /v\d+\.\d+\.\d+$/
-      - build-darwin-node-7:
           filters:
             tags:
               only: /v\d+\.\d+\.\d+$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,5 @@
 version: 2.1
 
-orbs:
-  win: circleci/windows@1.0.0
-
 commands:
   build:
     description: "Checkout, build, and test the package"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,237 @@
+version: 2.1
+
+orbs:
+  win: circleci/windows@1.0.0
+
+commands:
+  build:
+    description: "Checkout, build, and test the package"
+    steps:
+      - checkout
+      - run:
+          name: submodule
+          command: git submodule update --init --recursive
+      - run:
+          name: install
+          command: npm install
+      - run:
+          name: test
+          command: npm test
+
+  release:
+    description: "Checkout, build, and test the package"
+    steps:
+      - run:
+          name: release
+          command: node scripts/circle-release.js
+      - persist_to_workspace:
+          root: .
+          paths:
+            - release/*
+
+  install-node:
+    description: "Install NVM and Node"
+    parameters:
+      version:
+        type: integer
+        default: 10
+    steps:
+      - run:
+          name: install
+          command: |
+            set +e             
+            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash
+
+            export NVM_DIR="$HOME/.nvm"
+            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+            [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+
+            nvm install << parameters.version >>
+            nvm alias default << parameters.version >>
+
+            echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV
+            echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
+jobs: 
+  build-linux-node-6:
+    docker: 
+      - image: circleci/node:6 
+    steps:
+      - build
+      - release
+
+  build-linux-node-7:
+    docker: 
+      - image: circleci/node:7 
+    steps: 
+      - build
+      - release
+     
+  build-linux-node-8:
+    docker: 
+      - image: circleci/node:8 
+    steps: 
+      - build
+      - release
+
+  build-linux-node-9:
+    docker: 
+      - image: circleci/node:9
+    steps: 
+      - build
+      - release
+
+  build-linux-node-10:
+    docker:
+      - image: circleci/node:10 
+    steps: 
+      - build
+      - release
+
+  build-linux-node-11:
+    docker:
+      - image: circleci/node:11
+    steps: 
+      - build
+      - release
+
+  build-darwin-node-6:
+    macos:
+      xcode: "10.0.0"
+    steps: 
+      - install-node:
+          version: 6
+      - build
+      - release
+
+  build-darwin-node-7:
+    macos:
+      xcode: "10.0.0"
+    steps: 
+      - install-node:
+          version: 7
+      - build
+      - release
+
+  build-darwin-node-8:
+    macos:
+      xcode: "10.0.0"
+    steps: 
+      - install-node:
+          version: 8
+      - build
+      - release
+
+  build-darwin-node-9:
+    macos:
+      xcode: "10.0.0"
+    steps: 
+      - install-node:
+          version: 9
+      - build
+      - release
+
+  build-darwin-node-10:
+    macos:
+      xcode: "10.0.0"
+    steps: 
+      - install-node:
+          version: 10
+      - build
+      - release
+
+  build-darwin-node-11:
+    macos:
+      xcode: "10.0.0"
+    steps: 
+      - install-node:
+          version: 11
+      - build
+      - release
+  
+  publish-github-release:
+    docker:
+      - image: cibuilds/github:0.10
+    steps:
+      - attach_workspace:
+          at: ./artifacts
+      - run:
+          name: "Publish Release on GitHub"
+          command: "ls ./artifacts/release"
+      - run:
+          name: "Publish Release on GitHub"
+          command: |
+            ghr -t ${CIRCLE_CI_GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${CIRCLE_TAG} ./artifacts/release/
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - build-linux-node-6:
+          filters:
+            tags:
+              only: /v\d+\.\d+\.\d+$/
+      - build-linux-node-7:
+          filters:
+            tags:
+              only: /v\d+\.\d+\.\d+$/
+      - build-linux-node-8:
+          filters:
+            tags:
+              only: /v\d+\.\d+\.\d+$/
+      - build-linux-node-9:
+          filters:
+            tags:
+              only: /v\d+\.\d+\.\d+$/
+      - build-linux-node-10:
+          filters:
+            tags:
+              only: /v\d+\.\d+\.\d+$/
+      - build-linux-node-11:
+          filters:
+            tags:
+              only: /v\d+\.\d+\.\d+$/
+      - build-darwin-node-6:
+          filters:
+            tags:
+              only: /v\d+\.\d+\.\d+$/
+      - build-darwin-node-7:
+          filters:
+            tags:
+              only: /v\d+\.\d+\.\d+$/
+      - build-darwin-node-8:
+          filters:
+            tags:
+              only: /v\d+\.\d+\.\d+$/
+      - build-darwin-node-9:
+          filters:
+            tags:
+              only: /v\d+\.\d+\.\d+$/
+      - build-darwin-node-10:
+          filters:
+            tags:
+              only: /v\d+\.\d+\.\d+$/
+      - build-darwin-node-11:
+          filters:
+            tags:
+              only: /v\d+\.\d+\.\d+$/
+
+      - publish-github-release:
+          requires:
+            - build-linux-node-6
+            - build-linux-node-7
+            - build-linux-node-8
+            - build-linux-node-9
+            - build-linux-node-10
+            - build-linux-node-11
+            - build-darwin-node-6
+            - build-darwin-node-7
+            - build-darwin-node-8
+            - build-darwin-node-9
+            - build-darwin-node-10
+            - build-darwin-node-11
+
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /v\d+\.\d+\.\d+$/

--- a/scripts/circle-release.js
+++ b/scripts/circle-release.js
@@ -1,0 +1,17 @@
+const fs = require('fs');
+
+var dir = 'release';
+
+if (!fs.existsSync(dir)){
+    fs.mkdirSync(dir);
+}
+
+fs.readdir('vendor/', (err, list) => {
+    const dirName = list[0];
+    const fileName = `${dirName}_binding.node`;
+    const filePath = `vendor/${dirName}/binding.node`;
+
+    fs.createReadStream(filePath).pipe(fs.createWriteStream(`${dir}/${fileName}`));
+
+    return console.log(fileName);
+});


### PR DESCRIPTION
On tag circleci will product the following artifacts:
- Linux 6-11
- darwin 6-11

Windows 6-11 to be in a follow on PR once CircleCI is wired into this repo. I cannot test windows machines on my fork due to circleci limitations on machine sizing on their free tier.