### PR TITLE
Fix outdated `git://` URL

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -77,7 +77,7 @@ function initSubmodules(cb) {
   console.log('Detected a git install');
   console.log('Cloning libSass into src/libsass');
 
-  var clone = spawn('git', ['clone', 'git@github.com:sass/libsass.git', './src/libsass']);
+  var clone = spawn('git', ['clone', 'https://github.com/sass/libsass.git', './src/libsass']);
   manageProcess(clone, function(err) {
     if (err) {
       cb(err);


### PR DESCRIPTION
This project is failing to build due to a pull of a repo via a [deprecated insecure URL](https://github.blog/2021-09-01-improving-git-protocol-security-github/)
I have corrected this issue.