### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "libsass"]
 	path = src/libsass
-	url = git://github.com/sass/libsass.git
+	url = https://github.com/sass/libsass.git
 [submodule "test/sass-spec"]
 	path = test/fixtures/spec
 	url = https://github.com/sass/sass-spec.git


### PR DESCRIPTION
https://github.blog/2021-09-01-improving-git-protocol-security-github/


```
$ npm install -g @bigcommerce/stencil-cli
npm WARN deprecated @hapi/boom@8.0.1: This version has been deprecated and is no longer supported or maintained
npm WARN deprecated @hapi/hapi@18.4.1: This version contains severe security issues and defects and should not be used! Please upgrade to the latest version of @hapi/hapi or consider a commercial license (https://github.com/hapijs/hapi/issues/4114)
npm WARN deprecated messageformat@0.2.2: Package renamed as '@messageformat/core', see messageformat.github.io for more details. 'messageformat' will eventually provide a polyfill for Intl.MessageFormat, once it's been defined by Unicode & ECMA.
npm WARN deprecated gulp-header@1.8.12: Removed event-stream from gulp-header
npm WARN deprecated coffee-script@1.7.1: CoffeeScript on NPM has moved to "coffeescript" (no hyphen)
npm WARN deprecated mkdirp@0.3.5: Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)
npm WARN deprecated minimatch@0.3.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm ERR! code 1
npm ERR! Command failed: git submodule update -q --init --recursive
npm ERR! warning: templates not found /tmp/pacote-git-template-tmp/git-clone-cf339e13
npm ERR! fatal: remote error: 
npm ERR!   The unauthenticated git protocol on port 9418 is no longer supported.
npm ERR! Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
npm ERR! fatal: clone of 'git://github.com/sass/libsass.git' into submodule path '/root/.npm/_cacache/tmp/git-clone-54650270/src/libsass' failed
npm ERR! Failed to clone 'src/libsass'. Retry scheduled
npm ERR! warning: templates not found /tmp/pacote-git-template-tmp/git-clone-cf339e13
npm ERR! warning: templates not found /tmp/pacote-git-template-tmp/git-clone-cf339e13
npm ERR! fatal: remote error: 
npm ERR!   The unauthenticated git protocol on port 9418 is no longer supported.
npm ERR! Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
npm ERR! fatal: clone of 'git://github.com/sass/libsass.git' into submodule path '/root/.npm/_cacache/tmp/git-clone-54650270/src/libsass' failed
npm ERR! Failed to clone 'src/libsass' a second time, aborting
npm ERR! 
npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2022-01-11T15_13_14_037Z-debug.log
```